### PR TITLE
Update mechafil-jax branch for pandas dependencies

### DIFF
--- a/mechafil/minting.py
+++ b/mechafil/minting.py
@@ -72,7 +72,7 @@ def compute_minting_trajectory_df(
     # Add cumulative rewards and get daily rewards minted
     df["cum_network_reward"] = df["cum_baseline_reward"] + df["cum_simple_reward"]
     
-    df["day_network_reward"] = df["cum_network_reward"].diff().fillna(method="backfill")
+    df["day_network_reward"] = df["cum_network_reward"].diff().bfill()
     # cum_network_reward_zero = df["cum_network_reward"].iloc[0]
     # print(cum_network_reward_zero)
     # day_network_reward = np.zeros(len(df)+1)

--- a/mechafil/power.py
+++ b/mechafil/power.py
@@ -307,8 +307,6 @@ def build_full_power_stats_df(
         {"date": pd.date_range(start=start_date, end=end_date, freq="d")}
     )
     power_df["date"] = power_df["date"].dt.date
-    power_df = power_df.merge(concat_df, on="date", how="left").fillna(
-        method="backfill"
-    )
+    power_df = power_df.merge(concat_df, on="date", how="left").bfill()
     power_df = power_df.iloc[:-1]
     return power_df

--- a/mechafil/supply.py
+++ b/mechafil/supply.py
@@ -112,16 +112,16 @@ def forecast_circulating_supply_df(
         )
         reward_delta = day_locked_rewards - day_reward_release
         # Update dataframe
-        df["day_locked_pledge"].iloc[day_idx] = day_locked_pledge
-        df["day_renewed_pledge"].iloc[day_idx] = day_renewed_pledge
-        df["network_locked_pledge"].iloc[day_idx] = (
-            df["network_locked_pledge"].iloc[day_idx - 1] + pledge_delta
+        df.loc[day_idx, "day_locked_pledge"] = day_locked_pledge
+        df.loc[day_idx, "day_renewed_pledge"] = day_renewed_pledge
+        df.loc[day_idx, "network_locked_pledge"] = (
+            df.loc[day_idx - 1, "network_locked_pledge"] + pledge_delta
         )
-        df["network_locked_reward"].iloc[day_idx] = (
-            df["network_locked_reward"].iloc[day_idx - 1] + reward_delta
+        df.loc[day_idx, "network_locked_reward"] = (
+            df.loc[day_idx - 1, "network_locked_reward"] + reward_delta
         )
-        df["network_locked"].iloc[day_idx] = (
-            df["network_locked"].iloc[day_idx - 1] + pledge_delta + reward_delta
+        df.loc[day_idx, "network_locked"] = (
+            df.loc[day_idx - 1, "network_locked"] + pledge_delta + reward_delta
         )
         # print('%s,%0.02f,%0.02f,%0.02f,%0.02f' % 
         #     ('mechafil', 
@@ -131,9 +131,9 @@ def forecast_circulating_supply_df(
         #     df["network_locked"].iloc[day_idx], )
         # )
         # Update gas burnt
-        if df["network_gas_burn"].iloc[day_idx] == 0.0:
-            df["network_gas_burn"].iloc[day_idx] = (
-                df["network_gas_burn"].iloc[day_idx - 1] + daily_burnt_fil
+        if df.loc[day_idx, "network_gas_burn"] == 0.0:
+            df.loc[day_idx, "network_gas_burn"] = (
+                df.loc[day_idx - 1, "network_gas_burn"] + daily_burnt_fil
             )
         # Find circulating supply balance and update
         # print('=> %s,%0.02f,%0.02f,%0.02f,%0.02f,%0.02f' % 
@@ -153,7 +153,7 @@ def forecast_circulating_supply_df(
             - df["network_locked"].iloc[day_idx]  # from simulation loop
             - df["network_gas_burn"].iloc[day_idx]  # comes from user inputs
         )
-        df["circ_supply"].iloc[day_idx] = max(circ_supply, 0)
+        df.loc[day_idx, "circ_supply"] = max(circ_supply, 0)
     return df
 
 
@@ -188,10 +188,10 @@ def initialise_circulating_supply_df(
         }
     )
     df["date"] = df["date"].dt.date
-    df["network_locked_pledge"].iloc[0] = locked_fil_zero / 2.0
-    df["network_locked_reward"].iloc[0] = locked_fil_zero / 2.0
-    df["network_locked"].iloc[0] = locked_fil_zero
-    df["circ_supply"].iloc[0] = circ_supply_zero
+    df.loc[0, "network_locked_pledge"] = locked_fil_zero / 2.0
+    df.loc[0, "network_locked_reward"] = locked_fil_zero / 2.0
+    df.loc[0, "network_locked"] = locked_fil_zero
+    df.loc[0, "circ_supply"] = circ_supply_zero
     df = df.merge(vest_df, on="date", how="inner")
     df = df.merge(mint_df.drop(columns=["days"]), on="date", how="inner")
     return df


### PR DESCRIPTION
# Update mechafil for pandas dependencies

## Summary

This PR updates the mechafil codebase to address pandas deprecation warnings and modernize DataFrame operations for compatibility with newer pandas versions.

## Changes Made

### Deprecated Method Replacements
- **`fillna(method="backfill")` → `bfill()`**: Updated deprecated fillna method calls in:
  - `mechafil/minting.py:75` - Computing daily network rewards
  - `mechafil/power.py:310` - Building power statistics DataFrame

### DataFrame Indexing Modernization  
- **`.iloc[index] =` → `.loc[index, column] =`**: Replaced deprecated chained assignment patterns with explicit `.loc` indexing in `mechafil/supply.py`:
  - Lines 115-122: Network locked pledge, reward, and total calculations
  - Lines 134-136: Gas burn updates  
  - Line 156: Circulating supply updates
  - Lines 191-194: Initial circulating supply DataFrame setup

## Technical Impact

- **Pandas Compatibility**: Ensures compatibility with pandas 2.0+ by removing deprecated methods
- **Code Quality**: Eliminates FutureWarning messages that would appear with newer pandas versions
- **Functionality**: No changes to computational logic or results - purely modernization updates